### PR TITLE
feat: added a text for a blank event screen

### DIFF
--- a/Chicago Library Events/Event screen/EventsView.swift
+++ b/Chicago Library Events/Event screen/EventsView.swift
@@ -16,30 +16,36 @@ struct EventsView: View {
         // `NavigationStack` is used to show the title, `.navigationTitle` is used to display the name
         //
         NavigationStack {
-                
+            // this statement checks if 'libraryEvents' is empty and show a text on the screen, if there is data then the information within the list will be displayed
+            if viewModel.libraryEvents.isEmpty {
+                Text("There is no events")
+            } else {
                 // `List` is used to show information within a row
-            List(viewModel.libraryEvents) { libraryEvent in
-				EventsRowView(title: libraryEvent.title, day: libraryEvent.day_of_the_week, description: libraryEvent.description, location: libraryEvent.location_name ?? "")
+                List(viewModel.libraryEvents) { libraryEvent in
+                    EventsRowView(title: libraryEvent.title, day: libraryEvent.day_of_the_week, description: libraryEvent.description, location: libraryEvent.location_name ?? "")
                         .listRowSeparator(.hidden)
                     
                 }
-            .overlay {
-                // This allows the progressView to show the overlay icon
-                if viewModel.isLoading == true {
-                   ProgressView()
-                }
+                .overlay {
+                    // This allows the progressView to show the overlay icon
+                    if viewModel.isLoading == true {
+                        ProgressView()
+                    }
                     
-            }
-        
+                }
+                
                 // `.navigationTitle` the modifier that is used for displaying the title on the screen, needs to be located in the `NavigationStack`
                 .navigationTitle(Text("Events"))
                 .listStyle(.plain)
-				.onAppear {
-					Task {
-						await viewModel.getChicagoLibraryEvents()
-					}
-				}
+                .onAppear {
+                    Task {
+                        await viewModel.getChicagoLibraryEvents()
+                    }
+                }
             }
+            
+        }
+        
     }
 }
 

--- a/Chicago Library Events/Event screen/View Model/EventsScreenViewModel.swift
+++ b/Chicago Library Events/Event screen/View Model/EventsScreenViewModel.swift
@@ -25,6 +25,7 @@ class EventsScreenViewModel: ObservableObject {
 			self.libraryEvents = try await apiServices.getChicagoLibraryEvents()
             // this hide the progress view
             isLoading = false
+            
 		} catch {
 			print("sdknsdkn")
 		}


### PR DESCRIPTION

Added text to the event screen to show when there is no event listed 

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/de594f50-8aae-4052-910a-26997624220a" />
